### PR TITLE
Add random delay from 25-250ms to help make clients less deterministic

### DIFF
--- a/src/go/verifier.go
+++ b/src/go/verifier.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"time"
@@ -64,10 +65,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		fmt.Println(err)
 	}
 	fmt.Println(string(requestDump))
-	// 50 ms sleep time to simulate actual travel of the data over the internet
+
+	// 25-250 ms sleep time to simulate actual travel of the data over the internet
 	// although it is likely that in practice clients & servers will run inside
 	// the local network of the university. But well.
-	time.Sleep(50 * time.Millisecond)
+	sleepval := 25 + rand.Intn(225)
+	time.Sleep(time.Duration(sleepval) * time.Millisecond)
 
 	if r.Method != "POST" || r.ContentLength == 0 {
 		http.Error(w, "No content received.", 400)
@@ -104,6 +107,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	for {
 		http.HandleFunc("/verify", handler)
 		println("Preparing to listen on port 4590...")


### PR DESCRIPTION
Hello!

I was working through A1 of ECE459 and wanted some additional uncertainty in request time to make sure that my logic for request handling was correct. I was finding that requests were completing in the same order they were made (which to some extent is expected).

These are the (minor) changes I made to add some variability to requests.

I understand that this could also cause uncertainty for marking scripts, which makes it a little challenging to use. Making it available in case it's of interest for the future.